### PR TITLE
feat: Add support for complex config merging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ Cargo.lock
 *swo
 
 config.yaml
+conf.d

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,3 +1,4 @@
+---
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.4.0
@@ -9,6 +10,20 @@ repos:
         exclude: '^docs/.*$'
   - repo: local
     hooks:
+      - id: fmt
+        name: fmt
+        description: Format files with cargo fmt.
+        entry: cargo fmt --
+        language: system
+        files: '\.rs$'
+        args: []
+      - id: cargo-check
+        name: cargo check
+        description: Check the package for errors.
+        entry: cargo check
+        language: system
+        files: '\.rs$'
+        pass_filenames: false
       - id: mdbook
         name: mdbook
         files: 'doc/book.md'

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,9 @@ path="src/bin/reporter.rs"
 axum = { version="~0.6" }
 axum-macros = { version="~0.3" }
 chrono = "~0.4"
+config = "~0.13"
 evalexpr = "~8.1"
+glob = "~0.3"
 jwt = "~0.16"
 itertools = "~0.10"
 hmac = "~0.12"
@@ -43,6 +45,7 @@ uuid = { version = "~1.3", features = ["v4", "fast-rng"] }
 
 [dev-dependencies]
 mockito = "~1.0"
+tempfile = "~3.5"
 tokio-test = "*"
 tower = { version = "0.4", features = ["util"] }
 hyper = { version = "0.14", features = ["full"] }

--- a/src/bin/convertor.rs
+++ b/src/bin/convertor.rs
@@ -55,9 +55,9 @@ async fn main() -> Result<(), Error> {
         .with(tracing_subscriber::fmt::layer())
         .init();
 
-    tracing::info!("Starting cloudmon-metrics");
+    tracing::info!("Starting cloudmon-metrics-convertor");
 
-    let config = Config::from_config_file("config.yaml");
+    let config = Config::new("config.yaml").unwrap();
     let mut state = AppState::new(config);
     state.process_config();
     let server_addr = state.config.get_socket_addr().clone();
@@ -111,7 +111,7 @@ async fn main() -> Result<(), Error> {
         .await
         .unwrap();
 
-    tracing::info!("Stopped cloudmon-metrics");
+    tracing::info!("Stopped cloudmon-metrics-convertor");
     Ok(())
 }
 

--- a/src/bin/reporter.rs
+++ b/src/bin/reporter.rs
@@ -56,7 +56,7 @@ async fn main() {
     tracing::info!("Starting cloudmon-metrics-reporter");
 
     // Parse config
-    let config = Config::from_config_file("config.yaml");
+    let config = Config::new("config.yaml").unwrap();
 
     // Set up CTRL+C handlers
     let ctrl_c = async {
@@ -124,11 +124,11 @@ async fn metric_watcher(config: &Config) {
             }
         }
     }
-    let sdb_config = config.status_dashboard.as_ref().expect("Status dashboard section is missing");
-    let status_report_url = format!(
-        "{}/api/v1/component_status",
-        sdb_config.url.clone(),
-    );
+    let sdb_config = config
+        .status_dashboard
+        .as_ref()
+        .expect("Status dashboard section is missing");
+    let status_report_url = format!("{}/api/v1/component_status", sdb_config.url.clone(),);
     let mut headers = HeaderMap::new();
     if let Some(ref secret) = sdb_config.secret {
         let key: Hmac<Sha256> = Hmac::new_from_slice(secret.as_bytes()).unwrap();


### PR DESCRIPTION
Add config crate with merging environment variables prefixed with MP_ in
order to allow setting more sensitive values not in the general config
file. Add support for merging config from conf.d elements placed in the
config.yaml/../conf.d/*.yaml
