### PR TITLE
fix: query health further in the past

### DIFF
--- a/src/bin/reporter.rs
+++ b/src/bin/reporter.rs
@@ -151,12 +151,12 @@ async fn metric_watcher(config: &Config) {
                         "http://localhost:{}/api/v1/health",
                         config.server.port
                     ))
-                    // Query env/service for time [-1min..now]
+                    // Query env/service for time [-2min..-1min]
                     .query(&[
                         ("environment", env.name.clone()),
                         ("service", component.0.clone()),
-                        ("from", "-1min".to_string()),
-                        ("to", "now".to_string()),
+                        ("from", "-2min".to_string()),
+                        ("to", "-1min".to_string()),
                     ])
                     .send()
                     .await


### PR DESCRIPTION
From time to time health status returns wrong value which is not
returned for the same interval later. Assuming there might be some
concurrency in graphite causing data to be distorted (i.e. since we use
precentages and similar stuff portion of metrics can be updated
while other portion is still not written). To try to eliminate this
the reported is modified to query interval not -1m..now, but -2m..-1m
